### PR TITLE
Large refactor and bug fixes for BlazeTextField floating label, BlazeRow and BlazeTableViewCell and BlazeTableViewController.

### DIFF
--- a/Blaze/BlazeTableViewController.h
+++ b/Blaze/BlazeTableViewController.h
@@ -30,6 +30,7 @@
 @property(nonatomic,strong) NSString *emptyTitle;
 @property(nonatomic,strong) UIColor *emptyBackgroundColor;
 @property(nonatomic,strong) NSDictionary *emptyTitleAttributes;
+@property(nonatomic,strong) UIView *emptyCustomView;
 @property(nonatomic) UITableViewCellSeparatorStyle filledTableViewCellSeparatorStyle;
 @property(nonatomic) UITableViewCellSeparatorStyle emptyTableViewCellSeparatorStyle;
 

--- a/Blaze/BlazeTableViewController.m
+++ b/Blaze/BlazeTableViewController.m
@@ -1029,6 +1029,11 @@
     }
 }
 
+- (UIView *)customViewForEmptyDataSet:(UIScrollView *)scrollView
+{
+    return self.emptyCustomView;
+}
+
 #pragma mark Dealloc
 
 -(void)dealloc

--- a/Blaze/Categories/UIScrollView+EmptyDataSet.m
+++ b/Blaze/Categories/UIScrollView+EmptyDataSet.m
@@ -942,6 +942,7 @@ Class dzn_baseClassToSwizzleForTarget(id target)
     if (_customView) {
         [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[customView]|" options:0 metrics:nil views:@{@"customView":_customView}]];
         [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[customView]|" options:0 metrics:nil views:@{@"customView":_customView}]];
+        
     }
     else {
         CGFloat width = CGRectGetWidth(self.frame) ? : CGRectGetWidth([UIScreen mainScreen].bounds);
@@ -1030,6 +1031,30 @@ Class dzn_baseClassToSwizzleForTarget(id target)
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
+    if(_customView != nil){
+        _customView.frame = self.frame;
+        point = [super convertPoint:point toView:_customView];
+        UIView *hitView = [_customView hitTest:point withEvent:event];
+        return hitView;
+    }else{
+        UIView *hitView = [super hitTest:point withEvent:event];
+        
+        // Return any UIControl instance such as buttons, segmented controls, switches, etc.
+        if ([hitView isKindOfClass:[UIControl class]]) {
+            return hitView;
+        }
+        
+        // Return either the contentView or customView
+        if ([hitView isEqual:_contentView] || [hitView isEqual:_customView]) {
+            return hitView;
+        }
+        return nil;
+    }
+    
+}
+/* Original code
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
     UIView *hitView = [super hitTest:point withEvent:event];
     
     // Return any UIControl instance such as buttons, segmented controls, switches, etc.
@@ -1044,6 +1069,7 @@ Class dzn_baseClassToSwizzleForTarget(id target)
     
     return nil;
 }
+ */
 
 @end
 

--- a/Blaze/Objects/BlazeRow.h
+++ b/Blaze/Objects/BlazeRow.h
@@ -14,6 +14,12 @@ typedef NS_ENUM(NSInteger, InputAccessoryViewType) {
     InputAccessoryViewCancelSave,
 };
 
+typedef NS_ENUM(NSInteger, FloatingLabelEnabledState) {
+    FloatingLabelStateUndetermined = -1,
+    FloatingLabelStateDisabled = 0,
+    FloatingLabelStateEnabled = 1,
+};
+
 @interface BlazeRow : NSObject
 {
     
@@ -190,11 +196,11 @@ typedef NS_ENUM(NSInteger, InputAccessoryViewType) {
 @property(nonatomic,strong) NSAttributedString *attributedPlaceholder;
 
 //Floating placeholder options
-@property(nonatomic) bool floatingPlaceholder;
+@property(nonatomic) FloatingLabelEnabledState floatingLabelEnabled;
 @property(nonatomic,strong) NSString *floatingTitle;
-@property(nonatomic,strong) UIFont *floatingLabelFont;
-@property(nonatomic,strong) UIColor *floatingPlaceholderColor;
-@property(nonatomic,strong) UIColor *floatingPlaceholderActiveColor;
+@property(nonatomic,strong) UIFont *floatingTitleFont;
+@property(nonatomic,strong) UIColor *floatingTitleColor;
+@property(nonatomic,strong) UIColor *floatingTitleActiveColor;
 
 //MultipleSelector
 @property(nonatomic) bool disableMultipleSelection;

--- a/Blaze/Objects/BlazeRow.m
+++ b/Blaze/Objects/BlazeRow.m
@@ -24,6 +24,16 @@
 
 #pragma mark Init with ID
 
+-(instancetype)init
+{
+    self = [super init];
+    if(!self) {
+        return nil;
+    }
+    self.floatingLabelEnabled = FloatingLabelStateUndetermined;
+    return self;
+}
+
 -(instancetype)initWithID:(int)ID
 {
     return [self initWithID:ID title:nil];

--- a/Blaze/Objects/BlazeRow.m
+++ b/Blaze/Objects/BlazeRow.m
@@ -66,6 +66,7 @@
     self.value = value;
     self.xibName = xibName;
     self.placeholder = placeholder;
+    self.floatingLabelEnabled = FloatingLabelStateUndetermined;
     
     return self;
 }
@@ -119,6 +120,7 @@
     self.xibName = xibName;
     self.placeholder = placeholder;
     self.segueIdentifier = segueIdentifier;
+    self.floatingLabelEnabled = FloatingLabelStateUndetermined;
     
     return self;
 }
@@ -156,6 +158,7 @@
     self.value = value;
     self.placeholder = placeholder;
     self.segueIdentifier = segueIdentifier;
+    self.floatingLabelEnabled = FloatingLabelStateUndetermined;
     
     return self;
 }

--- a/Blaze/TableViewCells/BlazeDateTableViewCell.m
+++ b/Blaze/TableViewCells/BlazeDateTableViewCell.m
@@ -65,32 +65,9 @@
         self.dateField.placeholder = self.row.placeholder;
     }
     
-    //Update for floating options
-    BOOL useFloatingLabel = false;
-    if(self.row.floatingLabelEnabled == FloatingLabelStateUndetermined)
-    {
-        useFloatingLabel = self.dateField.useFloatingLabel;
-    } else {
-        useFloatingLabel = (BOOL)self.row.floatingLabelEnabled;
-    }
-    self.dateField.useFloatingLabel = useFloatingLabel;
+    //Merge BlazeRow's configuration with the BlazeTextField
+    [self.dateField mergeBlazeRowWithInspectables:self.row];
     
-    if(useFloatingLabel) {
-        self.dateField.flFont = self.row.floatingTitleFont;
-        if(self.row.floatingTitleColor) {
-            self.dateField.flTextColor = self.row.floatingTitleColor;
-        } else if(self.dateField.flTextColor) {
-            self.row.floatingTitleColor = self.dateField.flTextColor;
-        }
-        if(self.row.floatingTitleActiveColor) {
-            self.dateField.flActiveTextColor = self.row.floatingTitleActiveColor;
-        } else if(self.dateField.flActiveTextColor) {
-            self.row.floatingTitleActiveColor = self.dateField.flActiveTextColor;
-        }
-        if(self.row.floatingTitle.length) {
-            self.dateField.flText = self.row.floatingTitle;
-        }
-    }
     //Editable
     self.dateField.userInteractionEnabled = !self.row.disableEditing;    
 }
@@ -150,8 +127,14 @@
 
 #pragma mark - UITextField Delegate
 
+-(void)textFieldDidEndEditing:(UITextField *)textField
+{
+    NSLog(@"DPF : ended %@", NSStringFromCGRect(textField.frame));
+}
+
 -(void)textFieldDidBeginEditing:(UITextField *)textField
 {
+    NSLog(@"DPF : begin %@", NSStringFromCGRect(textField.frame));
     if(self.row.inputAccessoryViewType == InputAccessoryViewCancelSave) {
         return;
     }

--- a/Blaze/TableViewCells/BlazeDateTableViewCell.m
+++ b/Blaze/TableViewCells/BlazeDateTableViewCell.m
@@ -66,24 +66,31 @@
     }
     
     //Update for floating options
-    self.dateField.useFloatingLabel = self.row.floatingPlaceholder;
-    if(self.row.floatingPlaceholder) {
-        self.dateField.flFont = self.row.floatingLabelFont;
-        if(self.row.floatingPlaceholderColor) {
-            self.dateField.flTextColor = self.row.floatingPlaceholderColor;
+    BOOL useFloatingLabel = false;
+    if(self.row.floatingLabelEnabled == FloatingLabelStateUndetermined)
+    {
+        useFloatingLabel = self.dateField.useFloatingLabel;
+    } else {
+        useFloatingLabel = (BOOL)self.row.floatingLabelEnabled;
+    }
+    self.dateField.useFloatingLabel = useFloatingLabel;
+    
+    if(useFloatingLabel) {
+        self.dateField.flFont = self.row.floatingTitleFont;
+        if(self.row.floatingTitleColor) {
+            self.dateField.flTextColor = self.row.floatingTitleColor;
         } else if(self.dateField.flTextColor) {
-            self.row.floatingPlaceholderColor = self.dateField.flTextColor;
+            self.row.floatingTitleColor = self.dateField.flTextColor;
         }
-        if(self.row.floatingPlaceholderActiveColor) {
-            self.dateField.flActiveTextColor = self.row.floatingPlaceholderActiveColor;
+        if(self.row.floatingTitleActiveColor) {
+            self.dateField.flActiveTextColor = self.row.floatingTitleActiveColor;
         } else if(self.dateField.flActiveTextColor) {
-            self.row.floatingPlaceholderActiveColor = self.dateField.flActiveTextColor;
+            self.row.floatingTitleActiveColor = self.dateField.flActiveTextColor;
         }
         if(self.row.floatingTitle.length) {
             self.dateField.flText = self.row.floatingTitle;
         }
     }
-    
     //Editable
     self.dateField.userInteractionEnabled = !self.row.disableEditing;    
 }

--- a/Blaze/TableViewCells/BlazePickerViewTableViewCell.m
+++ b/Blaze/TableViewCells/BlazePickerViewTableViewCell.m
@@ -42,42 +42,8 @@
         index = [pickerValues indexOfObject:textValue];
     }
     
-    //Placeholder
-    if(self.row.attributedPlaceholder.length) {
-        self.pickerField.attributedPlaceholder = self.row.attributedPlaceholder;
-    }
-    else if(self.row.placeholder.length && self.row.placeholderColor) {
-        self.pickerField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.row.placeholder attributes:@{NSForegroundColorAttributeName:self.row.placeholderColor}];
-    }
-    else if(self.row.placeholder.length) {
-        self.pickerField.placeholder = self.row.placeholder;
-    }
-    
-    //Update for floating options
-    BOOL useFloatingLabel = false;
-    if(self.row.floatingLabelEnabled == FloatingLabelStateUndetermined)
-    {
-        useFloatingLabel = self.pickerField.useFloatingLabel;
-    } else {
-        useFloatingLabel = (BOOL)self.row.floatingLabelEnabled;
-    }
-    self.pickerField.useFloatingLabel = useFloatingLabel;
-    if(useFloatingLabel) {
-        self.pickerField.flFont = self.row.floatingTitleFont;
-        if(self.row.floatingTitleColor) {
-            self.pickerField.flTextColor = self.row.floatingTitleColor;
-        } else if(self.pickerField.flTextColor) {
-            self.row.floatingTitleColor = self.pickerField.flTextColor;
-        }
-        if(self.row.floatingTitleActiveColor) {
-            self.pickerField.flActiveTextColor = self.row.floatingTitleActiveColor;
-        } else if(self.pickerField.flActiveTextColor) {
-            self.row.floatingTitleActiveColor = self.pickerField.flActiveTextColor;
-        }
-        if(self.row.floatingTitle.length) {
-            self.pickerField.flText = self.row.floatingTitle;
-        }
-    }
+    //Merge BlazeRow's configuration with the BlazeTextField
+    [self.pickerField mergeBlazeRowWithInspectables:self.row];
     
     //No index check
     if(index == NSNotFound) {

--- a/Blaze/TableViewCells/BlazePickerViewTableViewCell.m
+++ b/Blaze/TableViewCells/BlazePickerViewTableViewCell.m
@@ -54,18 +54,25 @@
     }
     
     //Update for floating options
-    self.pickerField.useFloatingLabel = self.row.floatingPlaceholder;
-    if(self.row.floatingPlaceholder) {
-        self.pickerField.flFont = self.row.floatingLabelFont;
-        if(self.row.floatingPlaceholderColor) {
-            self.pickerField.flTextColor = self.row.floatingPlaceholderColor;
+    BOOL useFloatingLabel = false;
+    if(self.row.floatingLabelEnabled == FloatingLabelStateUndetermined)
+    {
+        useFloatingLabel = self.pickerField.useFloatingLabel;
+    } else {
+        useFloatingLabel = (BOOL)self.row.floatingLabelEnabled;
+    }
+    self.pickerField.useFloatingLabel = useFloatingLabel;
+    if(useFloatingLabel) {
+        self.pickerField.flFont = self.row.floatingTitleFont;
+        if(self.row.floatingTitleColor) {
+            self.pickerField.flTextColor = self.row.floatingTitleColor;
         } else if(self.pickerField.flTextColor) {
-            self.row.floatingPlaceholderColor = self.pickerField.flTextColor;
+            self.row.floatingTitleColor = self.pickerField.flTextColor;
         }
-        if(self.row.floatingPlaceholderActiveColor) {
-            self.pickerField.flActiveTextColor = self.row.floatingPlaceholderActiveColor;
+        if(self.row.floatingTitleActiveColor) {
+            self.pickerField.flActiveTextColor = self.row.floatingTitleActiveColor;
         } else if(self.pickerField.flActiveTextColor) {
-            self.row.floatingPlaceholderActiveColor = self.pickerField.flActiveTextColor;
+            self.row.floatingTitleActiveColor = self.pickerField.flActiveTextColor;
         }
         if(self.row.floatingTitle.length) {
             self.pickerField.flText = self.row.floatingTitle;

--- a/Blaze/TableViewCells/BlazeTextFieldTableViewCell.m
+++ b/Blaze/TableViewCells/BlazeTextFieldTableViewCell.m
@@ -37,32 +37,8 @@
         self.textField.placeholder = self.row.placeholder;
     }
     
-    //Update for floating options
-    BOOL useFloatingLabel = false;
-    if(self.row.floatingLabelEnabled == FloatingLabelStateUndetermined)
-    {
-        useFloatingLabel = self.textField.useFloatingLabel;
-    } else {
-        useFloatingLabel = (BOOL)self.row.floatingLabelEnabled;
-    }
-    self.textField.useFloatingLabel = useFloatingLabel;
-    
-    if(useFloatingLabel) {
-        self.textField.flFont = self.row.floatingTitleFont;
-        if(self.row.floatingTitleColor) {
-            self.textField.flTextColor = self.row.floatingTitleColor;
-        } else if(self.textField.flTextColor) {
-            self.row.floatingTitleColor = self.textField.flTextColor;
-        }
-        if(self.row.floatingTitleActiveColor) {
-            self.textField.flActiveTextColor = self.row.floatingTitleActiveColor;
-        } else if(self.textField.flActiveTextColor) {
-            self.row.floatingTitleActiveColor = self.textField.flActiveTextColor;
-        }
-        if(self.row.floatingTitle.length) {
-            self.textField.flText = self.row.floatingTitle;
-        }
-    }
+    //Merge BlazeRow's configuration with the BlazeTextField
+    [self.textField mergeBlazeRowWithInspectables:self.row];
     
     //Editable
     self.textField.userInteractionEnabled = !self.row.disableEditing;    

--- a/Blaze/TableViewCells/BlazeTextFieldTableViewCell.m
+++ b/Blaze/TableViewCells/BlazeTextFieldTableViewCell.m
@@ -38,18 +38,26 @@
     }
     
     //Update for floating options
-    self.textField.useFloatingLabel = self.row.floatingPlaceholder;
-    if(self.row.floatingPlaceholder) {
-        self.textField.flFont = self.row.floatingLabelFont;
-        if(self.row.floatingPlaceholderColor) {
-            self.textField.flTextColor = self.row.floatingPlaceholderColor;
+    BOOL useFloatingLabel = false;
+    if(self.row.floatingLabelEnabled == FloatingLabelStateUndetermined)
+    {
+        useFloatingLabel = self.textField.useFloatingLabel;
+    } else {
+        useFloatingLabel = (BOOL)self.row.floatingLabelEnabled;
+    }
+    self.textField.useFloatingLabel = useFloatingLabel;
+    
+    if(useFloatingLabel) {
+        self.textField.flFont = self.row.floatingTitleFont;
+        if(self.row.floatingTitleColor) {
+            self.textField.flTextColor = self.row.floatingTitleColor;
         } else if(self.textField.flTextColor) {
-            self.row.floatingPlaceholderColor = self.textField.flTextColor;
+            self.row.floatingTitleColor = self.textField.flTextColor;
         }
-        if(self.row.floatingPlaceholderActiveColor) {
-            self.textField.flActiveTextColor = self.row.floatingPlaceholderActiveColor;
+        if(self.row.floatingTitleActiveColor) {
+            self.textField.flActiveTextColor = self.row.floatingTitleActiveColor;
         } else if(self.textField.flActiveTextColor) {
-            self.row.floatingPlaceholderActiveColor = self.textField.flActiveTextColor;
+            self.row.floatingTitleActiveColor = self.textField.flActiveTextColor;
         }
         if(self.row.floatingTitle.length) {
             self.textField.flText = self.row.floatingTitle;

--- a/Blaze/TextFields/BlazeDatePickerField.m
+++ b/Blaze/TextFields/BlazeDatePickerField.m
@@ -55,7 +55,7 @@
     [self resignFirstResponder];
     if(self.dateCancelled) {
         self.dateCancelled();
-    }    
+    }
 }
 
 -(void)dateValueChanged

--- a/Blaze/TextFields/BlazeTextField.h
+++ b/Blaze/TextFields/BlazeTextField.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+@class BlazeRow;
+
 IB_DESIGNABLE
 
 @interface BlazeTextField : UITextField
@@ -97,7 +99,7 @@ IB_DESIGNABLE
  * Indicates whether or not to drop the baseline when entering text. Setting to YES (not the default) means the standard greyed-out placeholder will be aligned with the entered text
  * Defaults to NO (standard placeholder will be above whatever text is entered)
  */
-@property(nonatomic,assign) IBInspectable BOOL flKeepBaseline;
+@property(nonatomic,assign) IBInspectable BOOL flAlterBaseline;
 
 /**
  * Force floating label to be always visible
@@ -110,5 +112,12 @@ IB_DESIGNABLE
  */
 @property(nonatomic,strong) IBInspectable UIColor *placeholderColor;
 
+
+/**
+ Merge the configuration on a BlazeRow object with IBInspectables
+
+ @param row The BlazeRow that configures this BlazeRowTextField
+ */
+-(void)mergeBlazeRowWithInspectables:(BlazeRow*)row;
 
 @end

--- a/Blaze/TextFields/BlazeTextField.h
+++ b/Blaze/TextFields/BlazeTextField.h
@@ -97,13 +97,13 @@ IB_DESIGNABLE
  * Indicates whether or not to drop the baseline when entering text. Setting to YES (not the default) means the standard greyed-out placeholder will be aligned with the entered text
  * Defaults to NO (standard placeholder will be above whatever text is entered)
  */
-@property(nonatomic,assign) BOOL keepBaseline;
+@property(nonatomic,assign) IBInspectable BOOL flKeepBaseline;
 
 /**
  * Force floating label to be always visible
  * Defaults to NO
  */
-@property(nonatomic,assign) BOOL alwaysShowFloatingLabel;
+@property(nonatomic,assign) IBInspectable BOOL flAlwaysShow;
 
 /**
  * Color of the placeholder

--- a/Blaze/TextFields/BlazeTextField.m
+++ b/Blaze/TextFields/BlazeTextField.m
@@ -12,10 +12,13 @@
 static CGFloat const kFloatingLabelShowAnimationDuration = 0.3f;
 static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 
+@interface BlazeTextField()
+
+@property(nonatomic) BOOL isFloatingLabelFontDefault;
+
+@end
+
 @implementation BlazeTextField
-{
-    BOOL _isFloatingLabelFontDefault;
-}
 
 -(instancetype)initWithFrame:(CGRect)frame
 {
@@ -38,21 +41,24 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 -(void)commonInit
 {
     _floatingLabel = [UILabel new];
-    _floatingLabel.alpha = 0.0f;
-    [self addSubview:_floatingLabel];
+    self.floatingLabel.alpha = 0.0f;
+    [self addSubview:self.floatingLabel];
     
     // some basic default fonts/colors
-    _flFont = [self defaultFloatingLabelFont];
-    _floatingLabel.font = _flFont;
-    _flTextColor = [UIColor grayColor];
-    _floatingLabel.textColor = _flTextColor;
-    _animateEvenIfNotFirstResponder = NO;
-    _floatingLabelShowAnimationDuration = kFloatingLabelShowAnimationDuration;
-    _floatingLabelHideAnimationDuration = kFloatingLabelHideAnimationDuration;
-    [self setflText:self.placeholder];
+    self.flFont = [self defaultFloatingLabelFont];
+    self.floatingLabel.font = self.flFont;
+    self.flTextColor = [UIColor grayColor];
+    self.floatingLabel.textColor = self.flTextColor;
+    self.floatingLabelShowAnimationDuration = kFloatingLabelShowAnimationDuration;
+    self.floatingLabelHideAnimationDuration = kFloatingLabelHideAnimationDuration;
+    self.floatingLabel.text = self.flText;
+    [self setCorrectPlaceholder:self.placeholder];
     
-    _adjustsClearButtonRect = YES;
-    _isFloatingLabelFontDefault = YES;
+    //self.flAlwaysShow = FALSE;
+    //self.flKeepBaseline = TRUE;
+    self.isFloatingLabelFontDefault = TRUE;
+    self.adjustsClearButtonRect = TRUE;
+    self.animateEvenIfNotFirstResponder = FALSE;
 }
 
 -(void)prepareForInterfaceBuilder
@@ -61,7 +67,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     [self layoutSubviews];
     [self setCorrectPlaceholder:self.placeholder];
     [self updateDefaultFloatingLabelFont];
-    [self setflText:self.flText];
+    self.floatingLabel.text = self.flText;
 }
 
 #pragma mark -
@@ -87,19 +93,19 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 {
     UIFont *derivedFont = [self defaultFloatingLabelFont];
     
-    if (_isFloatingLabelFontDefault) {
+    if (self.isFloatingLabelFontDefault) {
         self.flFont = derivedFont;
     }
     else {
         // dont apply to the label, just store for future use where floatingLabelFont may be reset to nil
-        _flFont = derivedFont;
+        self.flFont = derivedFont;
     }
 }
 
 -(UIColor *)labelActiveColor
 {
-    if (_flActiveTextColor) {
-        return _flActiveTextColor;
+    if (self.flActiveTextColor) {
+        return self.flActiveTextColor;
     }
     else if ([self respondsToSelector:@selector(tintColor)]) {
         return [self performSelector:@selector(tintColor)];
@@ -107,28 +113,28 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     return [UIColor blueColor];
 }
 
--(void)setflFont:(UIFont *)flFont
+-(void)setFlFont:(UIFont *)flFont
 {
     if (flFont != nil) {
         _flFont = flFont;
     }
-    _floatingLabel.font = _flFont ? _flFont : [self defaultFloatingLabelFont];
-    _isFloatingLabelFontDefault = flFont == nil;
+    self.floatingLabel.font = self.flFont ? self.flFont : [self defaultFloatingLabelFont];
+    self.isFloatingLabelFontDefault = flFont == nil;
     [self invalidateIntrinsicContentSize];
 }
 
 -(void)showFloatingLabel:(BOOL)animated
-{    
+{
     void (^showBlock)() = ^{
-        _floatingLabel.alpha = 1.0f;
-        _floatingLabel.frame = CGRectMake(_floatingLabel.frame.origin.x,
-                                          _flYPadding,
-                                          _floatingLabel.frame.size.width,
-                                          _floatingLabel.frame.size.height);
+        self.floatingLabel.alpha = 1.0f;
+        self.floatingLabel.frame = CGRectMake(self.floatingLabel.frame.origin.x,
+                                          self.flYPadding,
+                                          self.floatingLabel.frame.size.width,
+                                          self.floatingLabel.frame.size.height);
     };
     
-    if (animated || 0 != _animateEvenIfNotFirstResponder) {
-        [UIView animateWithDuration:_floatingLabelShowAnimationDuration
+    if (animated || 0 != self.animateEvenIfNotFirstResponder) {
+        [UIView animateWithDuration:self.floatingLabelShowAnimationDuration
                               delay:0.0f
                             options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseOut
                          animations:showBlock
@@ -142,16 +148,16 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 -(void)hideFloatingLabel:(BOOL)animated
 {
     void (^hideBlock)() = ^{
-        _floatingLabel.alpha = 0.0f;
-        _floatingLabel.frame = CGRectMake(_floatingLabel.frame.origin.x,
-                                          _floatingLabel.font.lineHeight + _placeholderYPadding,
-                                          _floatingLabel.frame.size.width,
-                                          _floatingLabel.frame.size.height);
+        self.floatingLabel.alpha = 0.0f;
+        self.floatingLabel.frame = CGRectMake(self.floatingLabel.frame.origin.x,
+                                          self.floatingLabel.font.lineHeight + self.placeholderYPadding,
+                                          self.floatingLabel.frame.size.width,
+                                          self.floatingLabel.frame.size.height);
         
     };
     
-    if (animated || 0 != _animateEvenIfNotFirstResponder) {
-        [UIView animateWithDuration:_floatingLabelHideAnimationDuration
+    if (animated || 0 != self.animateEvenIfNotFirstResponder) {
+        [UIView animateWithDuration:self.floatingLabelHideAnimationDuration
                               delay:0.0f
                             options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseIn
                          animations:hideBlock
@@ -169,27 +175,39 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     CGFloat originX = textRect.origin.x;
     
     if (self.textAlignment == NSTextAlignmentCenter) {
-        originX = textRect.origin.x + (textRect.size.width/2) - (_floatingLabel.frame.size.width/2);
+        originX = textRect.origin.x + (textRect.size.width/2) - (self.floatingLabel.frame.size.width/2);
     }
     else if (self.textAlignment == NSTextAlignmentRight) {
-        originX = textRect.origin.x + textRect.size.width - _floatingLabel.frame.size.width;
+        originX = textRect.origin.x + textRect.size.width - self.floatingLabel.frame.size.width;
     }
     else if (self.textAlignment == NSTextAlignmentNatural) {
-        JVTextDirection baseDirection = [_floatingLabel.text getBaseDirection];
+        JVTextDirection baseDirection = [self.floatingLabel.text getBaseDirection];
         if (baseDirection == JVTextDirectionRightToLeft) {
-            originX = textRect.origin.x + textRect.size.width - _floatingLabel.frame.size.width;
+            originX = textRect.origin.x + textRect.size.width - self.floatingLabel.frame.size.width;
         }
     }
     
-    _floatingLabel.frame = CGRectMake(originX + _floatingLabelXPadding, _floatingLabel.frame.origin.y,
-                                      _floatingLabel.frame.size.width, _floatingLabel.frame.size.height);
+    self.floatingLabel.frame = CGRectMake(originX + self.floatingLabelXPadding, self.floatingLabel.frame.origin.y,
+                                      self.floatingLabel.frame.size.width, self.floatingLabel.frame.size.height);
 }
 
--(void)setflText:(NSString *)text
+-(void)setFlText:(NSString *)flText
 {
-    _flText = text;
-    _floatingLabel.text = text;
+    _flText = flText;
+    self.floatingLabel.text = flText;
     [self setNeedsLayout];
+}
+
+-(void)setFlAlwaysShow:(BOOL)flAlwaysShow
+{
+    _flAlwaysShow = flAlwaysShow;
+    [self setNeedsLayout];
+}
+
+-(void)setPlaceholderColor:(UIColor *)placeholderColor
+{
+    _placeholderColor = placeholderColor;
+    [self setCorrectPlaceholder:self.placeholder];
 }
 
 #pragma mark - UITextField
@@ -212,9 +230,9 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
         return [super intrinsicContentSize];
     }
     CGSize textFieldIntrinsicContentSize = [super intrinsicContentSize];
-    [_floatingLabel sizeToFit];
+    [self.floatingLabel sizeToFit];
     return CGSizeMake(textFieldIntrinsicContentSize.width,
-                      textFieldIntrinsicContentSize.height + _flYPadding + _floatingLabel.bounds.size.height);
+                      textFieldIntrinsicContentSize.height + self.flYPadding + self.floatingLabel.bounds.size.height);
 }
 
 -(void)setCorrectPlaceholder:(NSString *)placeholder
@@ -231,13 +249,17 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 -(void)setPlaceholder:(NSString *)placeholder
 {
     [self setCorrectPlaceholder:placeholder];
-    [self setflText:placeholder];
+    if(!self.flText.length) {
+        [self setFlText:placeholder];
+    }
 }
 
 -(void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder
 {
     [super setAttributedPlaceholder:attributedPlaceholder];
-    [self setflText:attributedPlaceholder.string];
+    if(!self.flText.length) {
+        [self setFlText:attributedPlaceholder.string];
+    }
     [self updateDefaultFloatingLabelFont];
 }
 
@@ -247,7 +269,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
         return [super textRectForBounds:bounds];
     }
     CGRect rect = [super textRectForBounds:bounds];
-    if ([self.text length] || self.keepBaseline) {
+    if ([self.text length] || self.flKeepBaseline) {
         rect = [self insetRectForBounds:rect];
     }
     return CGRectIntegral(rect);
@@ -259,7 +281,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
         return [super editingRectForBounds:bounds];
     }
     CGRect rect = [super editingRectForBounds:bounds];
-    if ([self.text length] || self.keepBaseline) {
+    if ([self.text length] || self.flKeepBaseline) {
         rect = [self insetRectForBounds:rect];
     }
     return CGRectIntegral(rect);
@@ -267,7 +289,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 
 -(CGRect)insetRectForBounds:(CGRect)rect
 {
-    CGFloat topInset = ceilf(_floatingLabel.bounds.size.height + _placeholderYPadding);
+    CGFloat topInset = ceilf(self.floatingLabel.bounds.size.height + self.placeholderYPadding);
     topInset = MIN(topInset, [self maxTopInset]);
     return CGRectMake(rect.origin.x, rect.origin.y + topInset / 2.0f, rect.size.width, rect.size.height);
 }
@@ -279,10 +301,10 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     }
     CGRect rect = [super clearButtonRectForBounds:bounds];
     if (0 != self.adjustsClearButtonRect
-        && _floatingLabel.text.length // for when there is no floating title label text
+        && self.floatingLabel.text.length // for when there is no floating title label text
         ) {
-        if ([self.text length] || self.keepBaseline) {
-            CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
+        if ([self.text length] || self.flKeepBaseline) {
+            CGFloat topInset = ceilf(self.floatingLabel.font.lineHeight + self.placeholderYPadding);
             topInset = MIN(topInset, [self maxTopInset]);
             rect = CGRectMake(rect.origin.x, rect.origin.y + topInset / 2.0f, rect.size.width, rect.size.height);
         }
@@ -297,7 +319,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     }
     CGRect rect = [super leftViewRectForBounds:bounds];
     
-    CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
+    CGFloat topInset = ceilf(self.floatingLabel.font.lineHeight + self.placeholderYPadding);
     topInset = MIN(topInset, [self maxTopInset]);
     rect = CGRectOffset(rect, 0, topInset / 2.0f);
     
@@ -311,7 +333,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     }
     CGRect rect = [super rightViewRectForBounds:bounds];
     
-    CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
+    CGFloat topInset = ceilf(self.floatingLabel.font.lineHeight + self.placeholderYPadding);
     topInset = MIN(topInset, [self maxTopInset]);
     rect = CGRectOffset(rect, 0, topInset / 2.0f);
     
@@ -329,12 +351,6 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     [self setNeedsLayout];
 }
 
--(void)setAlwaysShowFloatingLabel:(BOOL)alwaysShowFloatingLabel
-{
-    _alwaysShowFloatingLabel = alwaysShowFloatingLabel;
-    [self setNeedsLayout];
-}
-
 -(void)layoutSubviews
 {
     [super layoutSubviews];
@@ -345,17 +361,17 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     
     [self setLabelOriginForTextAlignment];
     
-    CGSize floatingLabelSize = [_floatingLabel sizeThatFits:_floatingLabel.superview.bounds.size];
+    CGSize floatingLabelSize = [self.floatingLabel sizeThatFits:self.floatingLabel.superview.bounds.size];
     
-    _floatingLabel.frame = CGRectMake(_floatingLabel.frame.origin.x,
-                                      _floatingLabel.frame.origin.y,
+    self.floatingLabel.frame = CGRectMake(self.floatingLabel.frame.origin.x,
+                                      self.floatingLabel.frame.origin.y,
                                       floatingLabelSize.width,
                                       floatingLabelSize.height);
     
     BOOL firstResponder = self.isFirstResponder;
-    _floatingLabel.textColor = (firstResponder && self.text && self.text.length > 0 ?
+    self.floatingLabel.textColor = (firstResponder ?
                                 self.labelActiveColor : self.flTextColor);
-    if ((!self.text || 0 == [self.text length]) && !self.alwaysShowFloatingLabel) {
+    if ((!self.text || 0 == [self.text length]) && !self.flAlwaysShow) {
         [self hideFloatingLabel:firstResponder];
     }
     else {

--- a/Example/BlazeExample.xcodeproj/project.pbxproj
+++ b/Example/BlazeExample.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		AFA93F01117D37C9C3CCD745 /* Pods_BlazeExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C00BA881BB68741859570A3 /* Pods_BlazeExample.framework */; };
+		B0944BE61DDAD1B700B66895 /* IBInspectableTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B0944BE51DDAD1B700B66895 /* IBInspectableTableViewController.m */; };
+		B0944BE81DDAD24900B66895 /* IBInspectableBlazeTextField.xib in Resources */ = {isa = PBXBuildFile; fileRef = B0944BE71DDAD24900B66895 /* IBInspectableBlazeTextField.xib */; };
 		B0CE2C121DACDEAA00A1A3C9 /* TilesTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B0CE2C111DACDEAA00A1A3C9 /* TilesTableViewCell.xib */; };
 		ED0297031D1729220039AA41 /* ButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED0296E11D1729220039AA41 /* ButtonTableViewCell.xib */; };
 		ED0297041D1729220039AA41 /* DateFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED0296E21D1729220039AA41 /* DateFieldTableViewCell.xib */; };
@@ -73,6 +75,9 @@
 		5C00BA881BB68741859570A3 /* Pods_BlazeExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlazeExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7414ACEAFC2C6C62B2C372A6 /* Pods-BlazeExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlazeExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BlazeExample/Pods-BlazeExample.debug.xcconfig"; sourceTree = "<group>"; };
 		9117633E2828C62B6A0A0603 /* Pods-BlazeExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlazeExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-BlazeExample/Pods-BlazeExample.release.xcconfig"; sourceTree = "<group>"; };
+		B0944BE41DDAD1B700B66895 /* IBInspectableTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IBInspectableTableViewController.h; sourceTree = "<group>"; };
+		B0944BE51DDAD1B700B66895 /* IBInspectableTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IBInspectableTableViewController.m; sourceTree = "<group>"; };
+		B0944BE71DDAD24900B66895 /* IBInspectableBlazeTextField.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IBInspectableBlazeTextField.xib; sourceTree = "<group>"; };
 		B0CE2C111DACDEAA00A1A3C9 /* TilesTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TilesTableViewCell.xib; sourceTree = "<group>"; };
 		ED0296DF1D1729220039AA41 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		ED0296E11D1729220039AA41 /* ButtonTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ButtonTableViewCell.xib; sourceTree = "<group>"; };
@@ -218,6 +223,7 @@
 				ED2626AF1D17EA9B00C3A1E4 /* CheckboxTableViewCell.xib */,
 				EDF0E7E61D4111570036AEDA /* TwoChoicesTableViewCell.xib */,
 				B0CE2C111DACDEAA00A1A3C9 /* TilesTableViewCell.xib */,
+				B0944BE71DDAD24900B66895 /* IBInspectableBlazeTextField.xib */,
 			);
 			path = TableViewCells;
 			sourceTree = "<group>";
@@ -250,6 +256,8 @@
 				ED0296FE1D1729220039AA41 /* TextViewsTableViewController.m */,
 				ED0296FF1D1729220039AA41 /* ZoomHeaderTableViewController.h */,
 				ED0297001D1729220039AA41 /* ZoomHeaderTableViewController.m */,
+				B0944BE41DDAD1B700B66895 /* IBInspectableTableViewController.h */,
+				B0944BE51DDAD1B700B66895 /* IBInspectableTableViewController.m */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -516,6 +524,7 @@
 				ED02970A1D1729220039AA41 /* SliderTableViewCell.xib in Resources */,
 				ED02970C1D1729220039AA41 /* TextArrowTableViewCell.xib in Resources */,
 				ED2626B01D17EA9B00C3A1E4 /* CheckboxTableViewCell.xib in Resources */,
+				B0944BE81DDAD24900B66895 /* IBInspectableBlazeTextField.xib in Resources */,
 				ED933E0D1D1728A100B8155F /* Assets.xcassets in Resources */,
 				ED0297081D1729220039AA41 /* PickerFieldTableViewCell.xib in Resources */,
 				ED0297101D1729220039AA41 /* TableHeaderView.xib in Resources */,
@@ -594,6 +603,7 @@
 				ED02976C1D1729370039AA41 /* BlazeTableViewCell.m in Sources */,
 				ED02976A1D1729370039AA41 /* BlazeSwitchTableViewCell.m in Sources */,
 				ED02975D1D1729370039AA41 /* BlazeInputTile.m in Sources */,
+				B0944BE61DDAD1B700B66895 /* IBInspectableTableViewController.m in Sources */,
 				ED0297181D1729220039AA41 /* ZoomHeaderTableViewController.m in Sources */,
 				ED0297171D1729220039AA41 /* TextViewsTableViewController.m in Sources */,
 				ED0297591D1729370039AA41 /* NSObject+PropertyName.m in Sources */,

--- a/Example/BlazeExample/Base.lproj/Main.storyboard
+++ b/Example/BlazeExample/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Qhh-P6-GEH">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Qhh-P6-GEH">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Basic cells-->
@@ -10,9 +14,9 @@
             <objects>
                 <tableViewController storyboardIdentifier="BasicTableViewController" id="ZdF-6J-Lgs" customClass="BasicTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="T8T-Bc-ZgB">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="ZdF-6J-Lgs" id="eTb-wh-4DM"/>
                             <outlet property="delegate" destination="ZdF-6J-Lgs" id="Yob-AI-TNQ"/>
@@ -28,14 +32,13 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8Wh-p4-qSx" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="608" y="235"/>
+            <point key="canvasLocation" x="606" y="-65"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="0Vu-py-ssX">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Qhh-P6-GEH" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="sxE-ot-7i4">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -47,16 +50,16 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0TM-I0-R7K" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="608" y="-321"/>
+            <point key="canvasLocation" x="607" y="-783"/>
         </scene>
         <!--Cell Types-->
         <scene sceneID="sJb-2c-Q65">
             <objects>
                 <tableViewController storyboardIdentifier="CellTypesTableViewController" id="z3f-t9-hhB" customClass="CellTypesTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="SkW-qp-6rQ">
-                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="z3f-t9-hhB" id="CBk-w8-g5w"/>
                             <outlet property="delegate" destination="z3f-t9-hhB" id="GO9-91-t91"/>
@@ -64,20 +67,19 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Cell Types" id="d2B-8e-2An"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UFy-1g-Hb6" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-106" y="791"/>
+            <point key="canvasLocation" x="-1038" y="778"/>
         </scene>
         <!--Dynamic Rows-->
         <scene sceneID="qSt-TF-JV9">
             <objects>
                 <tableViewController storyboardIdentifier="DynamicRowsTableViewController" id="Upf-jc-Le4" customClass="DynamicRowsTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="uV8-0n-EnH">
-                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="Upf-jc-Le4" id="hXi-hL-TZ1"/>
                             <outlet property="delegate" destination="Upf-jc-Le4" id="pxC-Dz-Nei"/>
@@ -85,20 +87,19 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Dynamic Rows" id="YIa-nY-RcN"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nXb-xr-E9w" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="256" y="791"/>
+            <point key="canvasLocation" x="-361" y="778"/>
         </scene>
         <!--Zoom Header-->
         <scene sceneID="v7F-Gj-MGP">
             <objects>
                 <tableViewController storyboardIdentifier="ZoomHeaderTableViewController" id="FLq-Ow-pw2" customClass="ZoomHeaderTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="edq-kw-ZRr">
-                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="FLq-Ow-pw2" id="hYT-Rn-BaX"/>
                             <outlet property="delegate" destination="FLq-Ow-pw2" id="8SL-IZ-5cQ"/>
@@ -106,20 +107,19 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Zoom Header" id="nSa-zl-4Pi"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Fla-rQ-hAX" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="608" y="791"/>
+            <point key="canvasLocation" x="330" y="778"/>
         </scene>
         <!--Empty State-->
         <scene sceneID="wTs-DR-jcw">
             <objects>
                 <tableViewController storyboardIdentifier="EmptyStateTableViewController" id="FCE-Gl-iTP" customClass="EmptyStateTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="Q4h-TK-7NS">
-                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="FCE-Gl-iTP" id="ecW-fx-kx8"/>
                             <outlet property="delegate" destination="FCE-Gl-iTP" id="8rE-4q-xDy"/>
@@ -127,20 +127,19 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Empty State" id="Jnc-NG-zv9"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="YEj-Gm-uNb" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1647" y="791"/>
+            <point key="canvasLocation" x="2465" y="778"/>
         </scene>
         <!--Row Heights-->
         <scene sceneID="M4Q-Up-fqT">
             <objects>
                 <tableViewController storyboardIdentifier="RowHeightsTableViewController" id="NKV-Hb-TXs" customClass="RowHeightsTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="bOX-iV-cgq">
-                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="NKV-Hb-TXs" id="1wf-98-7JR"/>
                             <outlet property="delegate" destination="NKV-Hb-TXs" id="pUd-le-8qs"/>
@@ -148,20 +147,19 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Row Heights" id="rXb-5w-Wiq"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5sK-ow-vs5" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1301" y="791"/>
+            <point key="canvasLocation" x="1738" y="778"/>
         </scene>
         <!--Textviews-->
         <scene sceneID="cjc-yH-SzW">
             <objects>
                 <tableViewController storyboardIdentifier="TextViewsTableViewController" id="e41-PT-gqe" customClass="TextViewsTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="tTi-ph-9GF">
-                        <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="e41-PT-gqe" id="FRW-Vr-LeI"/>
                             <outlet property="delegate" destination="e41-PT-gqe" id="3VJ-4e-KKA"/>
@@ -169,11 +167,30 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Textviews" id="2RU-yA-pBI"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="R7m-WU-RrA" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="959" y="791"/>
+            <point key="canvasLocation" x="1028" y="778"/>
+        </scene>
+        <!--IBInspectables-->
+        <scene sceneID="c2A-5X-ITz">
+            <objects>
+                <tableViewController storyboardIdentifier="IBInspectableTableViewController" id="CPU-d1-raS" customClass="IBInspectableTableViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="spL-Nq-KYB">
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <connections>
+                            <outlet property="dataSource" destination="CPU-d1-raS" id="iOn-lD-sb4"/>
+                            <outlet property="delegate" destination="CPU-d1-raS" id="2zZ-W3-9Nc"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="IBInspectables" id="TCq-WV-ftg"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="b6E-Dw-e7X" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3142" y="778"/>
         </scene>
     </scenes>
 </document>

--- a/Example/BlazeExample/TableViewCells/DateFieldTableViewCell.xib
+++ b/Example/BlazeExample/TableViewCells/DateFieldTableViewCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="61"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ilx-w2-40b" id="4p5-Fn-rn3">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="60.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dQI-Du-kmf">
@@ -20,18 +24,21 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d37-n9-xxZ">
                                 <rect key="frame" x="20" y="20" width="34" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1Ng-e4-zaL" customClass="BlazeDatePickerField">
-                                <rect key="frame" x="80" y="20" width="220" height="20"/>
-                                <color key="tintColor" red="0.0" green="0.56862745098039214" blue="0.91764705882352937" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="textColor" red="0.96078431369999995" green="0.6705882353" blue="0.20784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="80" y="10" width="220" height="40"/>
+                                <color key="tintColor" red="0.0" green="0.56862745098039214" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="U31-rs-zQN"/>
+                                </constraints>
+                                <color key="textColor" red="0.96078431369999995" green="0.6705882353" blue="0.20784313730000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="1Ng-e4-zaL" firstAttribute="leading" secondItem="dQI-Du-kmf" secondAttribute="leading" constant="32" id="FgT-sn-XY2"/>
                             <constraint firstItem="d37-n9-xxZ" firstAttribute="centerY" secondItem="dQI-Du-kmf" secondAttribute="centerY" id="He5-4I-uLi"/>

--- a/Example/BlazeExample/TableViewCells/FloatTextFieldTableViewCell.xib
+++ b/Example/BlazeExample/TableViewCells/FloatTextFieldTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2657" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina3_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -27,17 +27,8 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <textInputTraits key="textInputTraits"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="floatingLabelTextColor">
-                                        <color key="value" red="0.83921568629999999" green="0.047058823530000002" blue="0.54901960780000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="floatingLabelYPadding">
-                                        <real key="value" value="0.0"/>
-                                    </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="placeholderColor">
                                         <color key="value" red="0.83921568629999999" green="0.047058823530000002" blue="0.54901960780000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="floatingLabelActiveTextColor">
-                                        <color key="value" red="0.94901960780000005" green="0.47058823529999999" blue="0.29411764709999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="useFloatingLabel" value="YES"/>
                                     <userDefinedRuntimeAttribute type="number" keyPath="flYPadding">

--- a/Example/BlazeExample/TableViewCells/IBInspectableBlazeTextField.xib
+++ b/Example/BlazeExample/TableViewCells/IBInspectableBlazeTextField.xib
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="82" id="4uB-op-0nl" customClass="BlazeTextFieldTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="82"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4uB-op-0nl" id="nSo-Je-vxQ">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="81"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Placeholder text" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rxg-lH-tPo" customClass="BlazeTextField">
+                        <rect key="frame" x="25" y="20" width="325" height="41.5"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="41.5" id="xrU-AT-59i"/>
+                        </constraints>
+                        <nil key="textColor"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="flText" value="Floating text"/>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="useFloatingLabel" value="YES"/>
+                            <userDefinedRuntimeAttribute type="color" keyPath="flTextColor">
+                                <color key="value" red="0.86274509799999999" green="0.0" blue="0.4039215686" alpha="1" colorSpace="calibratedRGB"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="color" keyPath="flActiveTextColor">
+                                <color key="value" red="0.0" green="0.6705882353" blue="0.62745098040000002" alpha="1" colorSpace="calibratedRGB"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderColor">
+                                <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="flYPadding">
+                                <real key="value" value="0.0"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="flKeepBaseline" value="YES"/>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="flAlwaysShow" value="YES"/>
+                        </userDefinedRuntimeAttributes>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="rxg-lH-tPo" firstAttribute="leading" secondItem="nSo-Je-vxQ" secondAttribute="leading" constant="25" id="DM5-M9-FWU"/>
+                    <constraint firstItem="rxg-lH-tPo" firstAttribute="top" secondItem="nSo-Je-vxQ" secondAttribute="top" constant="20" id="Jcn-nQ-fZf"/>
+                    <constraint firstAttribute="bottom" secondItem="rxg-lH-tPo" secondAttribute="bottom" constant="20" id="SNm-hU-D0N"/>
+                    <constraint firstAttribute="trailing" secondItem="rxg-lH-tPo" secondAttribute="trailing" constant="25" id="daH-Xy-tw2"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="textField" destination="rxg-lH-tPo" id="8ML-oq-1Wq"/>
+            </connections>
+            <point key="canvasLocation" x="-84.5" y="12"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Example/BlazeExample/TableViewCells/IBInspectableBlazeTextField.xib
+++ b/Example/BlazeExample/TableViewCells/IBInspectableBlazeTextField.xib
@@ -15,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="82"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4uB-op-0nl" id="nSo-Je-vxQ">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="81"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="82"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Placeholder text" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rxg-lH-tPo" customClass="BlazeTextField">
@@ -41,7 +41,6 @@
                             <userDefinedRuntimeAttribute type="number" keyPath="flYPadding">
                                 <real key="value" value="0.0"/>
                             </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="boolean" keyPath="flKeepBaseline" value="YES"/>
                             <userDefinedRuntimeAttribute type="boolean" keyPath="flAlwaysShow" value="YES"/>
                         </userDefinedRuntimeAttributes>
                     </textField>

--- a/Example/BlazeExample/TableViewCells/PickerFieldTableViewCell.xib
+++ b/Example/BlazeExample/TableViewCells/PickerFieldTableViewCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="61"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ilx-w2-40b" id="4p5-Fn-rn3">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="60.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dQI-Du-kmf">
@@ -20,18 +24,18 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d37-n9-xxZ">
                                 <rect key="frame" x="20" y="20" width="34" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1Ng-e4-zaL" customClass="BlazePickerViewField">
                                 <rect key="frame" x="80" y="20" width="220" height="20"/>
-                                <color key="tintColor" red="0.0" green="0.56862745098039214" blue="0.91764705882352937" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="textColor" red="0.96078431369999995" green="0.6705882353" blue="0.20784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" red="0.0" green="0.56862745098039214" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="textColor" red="0.96078431369999995" green="0.6705882353" blue="0.20784313730000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="1Ng-e4-zaL" firstAttribute="leading" secondItem="dQI-Du-kmf" secondAttribute="leading" constant="32" id="FgT-sn-XY2"/>
                             <constraint firstItem="d37-n9-xxZ" firstAttribute="centerY" secondItem="dQI-Du-kmf" secondAttribute="centerY" id="He5-4I-uLi"/>

--- a/Example/BlazeExample/TableViewCells/TextTableViewCell.xib
+++ b/Example/BlazeExample/TableViewCells/TextTableViewCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -23,7 +27,7 @@
                                     <constraint firstAttribute="height" constant="21" id="lhU-Km-KXL"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -32,7 +36,7 @@
                                 </variation>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="K0E-Kd-SzV" firstAttribute="leading" secondItem="Dze-SA-vhE" secondAttribute="leading" constant="20" id="0jU-04-ePV"/>
                             <constraint firstItem="K0E-Kd-SzV" firstAttribute="centerY" secondItem="Dze-SA-vhE" secondAttribute="centerY" id="4tn-3O-R9M"/>

--- a/Example/BlazeExample/ViewControllers/BaseTableViewController.h
+++ b/Example/BlazeExample/ViewControllers/BaseTableViewController.h
@@ -26,6 +26,7 @@
 #define kFloatTextFieldTableViewCell    @"FloatTextFieldTableViewCell"
 #define kSegmentedControlTableViewCell  @"SegmentedControlTableViewCell"
 #define kTilesTableViewCell             @"TilesTableViewCell"
+#define kIBInspectableBlazeTextField    @"IBInspectableBlazeTextField"
 
 @interface BaseTableViewController : BlazeTableViewController
 {

--- a/Example/BlazeExample/ViewControllers/BasicTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/BasicTableViewController.m
@@ -81,6 +81,13 @@
     
     //Segue again
     [section addRow:[[BlazeRow alloc] initWithTitle:@"Empty state" segueIdentifier:@"EmptyStateTableViewController"]];
+    
+    //Row with push using cellTap completion block and storyboard instantiation
+    row = [BlazeRow rowWithTitle:@"IBInspectables"];
+    [row setCellTapped:^{
+        [self.navigationController pushViewController:[[UIStoryboard storyboardWithName:@"Main" bundle:nil] instantiateViewControllerWithIdentifier:@"IBInspectableTableViewController"] animated:TRUE];
+    }];
+    [section addRow:row];
 }
 
 @end

--- a/Example/BlazeExample/ViewControllers/CellTypesTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/CellTypesTableViewController.m
@@ -50,9 +50,9 @@
     
     //Textfield
     row = [[BlazeRow alloc] initWithXibName:kFloatTextFieldTableViewCell];
-    row.floatingPlaceholder = TRUE;
-    row.floatingPlaceholderActiveColor = [UIColor redColor];
-    row.floatingLabelFont = [UIFont italicSystemFontOfSize:12.0f];
+    row.floatingLabelEnabled = TRUE;
+    row.floatingTitleActiveColor = [UIColor redColor];
+    row.floatingTitleFont = [UIFont italicSystemFontOfSize:12.0f];
     row.floatingTitle = @"Floating placeholder";
     [row setAffectedObject:self affectedPropertyName:[self stringForPropertyName:@selector(textfieldValue)]];
     row.placeholder = @"Placeholder";
@@ -70,11 +70,11 @@
     row.placeholder = @"Which date?";
     row.dateMinuteInterval = 5;
     row.datePickerMode = UIDatePickerModeDateAndTime;
-    row.floatingPlaceholder = TRUE;
+    row.floatingLabelEnabled = FloatingLabelStateEnabled;
     row.placeholderColor = [UIColor orangeColor];
-    row.floatingPlaceholderColor = [UIColor redColor];
-    row.floatingPlaceholderActiveColor = [UIColor purpleColor];
-    row.floatingLabelFont = [UIFont systemFontOfSize:12.0f weight:UIFontWeightBold];
+    row.floatingTitleColor = [UIColor redColor];
+    row.floatingTitleActiveColor = [UIColor purpleColor];
+    row.floatingTitleFont = [UIFont systemFontOfSize:12.0f weight:UIFontWeightBold];
     row.floatingTitle = @"Date set!";
     NSDateFormatter *df = [NSDateFormatter new];
     [df setDateFormat:@"d MMMM yyyy HH:mm"];
@@ -85,10 +85,10 @@
     //Picker
     row = [[BlazeRow alloc] initWithXibName:kPickerFieldTableViewCell title:@"Pickerfield"];
     row.placeholder = @"Picker placeholder";
-    row.floatingPlaceholder = TRUE;
-    row.floatingPlaceholderColor = [UIColor greenColor];
-    row.floatingPlaceholderActiveColor = [UIColor greenColor];
-    row.floatingLabelFont = [UIFont systemFontOfSize:14.0f weight:UIFontWeightLight];
+    row.floatingLabelEnabled = TRUE;
+    row.floatingTitleColor = [UIColor greenColor];
+    row.floatingTitleActiveColor = [UIColor greenColor];
+    row.floatingTitleFont = [UIFont systemFontOfSize:14.0f weight:UIFontWeightLight];
     row.floatingTitle = @"Picker set!";
     [row setAffectedObject:self affectedPropertyName:[self stringForPropertyName:@selector(pickerValue)]];
     row.selectorOptions = @[@"Automatic next/previous", @"buttons always work", @"Doesn't matter if you", @"use textfields", @"or datepickers", @"or pickerviews", @"or multiple sections"];

--- a/Example/BlazeExample/ViewControllers/EmptyStateTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/EmptyStateTableViewController.m
@@ -17,13 +17,24 @@
 -(void)viewDidLoad
 {
     [super viewDidLoad];
-    
     //Empty state
     self.emptyImage = [UIImage imageNamed:@"Blaze_Logo"];
     self.emptyBackgroundColor = [UIColor whiteColor];
     self.emptyVerticalOffset = -100.0f;
     self.emptyTitle = @"This is an example text for an empty state, you can provide colors, atributed text, image, background color, etc.\nCredits to DZNEmptyDataSet!";
     self.emptyTitleAttributes = @{NSFontAttributeName:[UIFont systemFontOfSize:18.0f weight:UIFontWeightLight], NSForegroundColorAttributeName:[UIColor darkGrayColor]};
+    self.emptyBackgroundColor = [UIColor redColor];
+    
+    //Empty state custom view
+    /*
+    UIView *view = [UIView new];
+    self.emptyVerticalOffset = -400.0f;
+    UILabel *lbl = [[UILabel alloc] initWithFrame:CGRectMake(50, 200, 250, 50)];
+    lbl.text = @"Custom label!";
+    lbl.backgroundColor = [UIColor yellowColor];
+    [view addSubview:lbl];
+    self.emptyCustomView = view;
+     */
 }
 
 @end

--- a/Example/BlazeExample/ViewControllers/EmptyStateTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/EmptyStateTableViewController.m
@@ -23,18 +23,32 @@
     self.emptyVerticalOffset = -100.0f;
     self.emptyTitle = @"This is an example text for an empty state, you can provide colors, atributed text, image, background color, etc.\nCredits to DZNEmptyDataSet!";
     self.emptyTitleAttributes = @{NSFontAttributeName:[UIFont systemFontOfSize:18.0f weight:UIFontWeightLight], NSForegroundColorAttributeName:[UIColor darkGrayColor]};
-    self.emptyBackgroundColor = [UIColor redColor];
     
-    //Empty state custom view
-    /*
+    //Empty state custom view with hitTest for UIButton subview
+/*
+    self.emptyBackgroundColor = [UIColor redColor];
     UIView *view = [UIView new];
-    self.emptyVerticalOffset = -400.0f;
+    self.emptyVerticalOffset = -300.0f;
     UILabel *lbl = [[UILabel alloc] initWithFrame:CGRectMake(50, 200, 250, 50)];
     lbl.text = @"Custom label!";
     lbl.backgroundColor = [UIColor yellowColor];
     [view addSubview:lbl];
+    
+    
+    UIButton *btn = [UIButton buttonWithType:UIButtonTypeCustom];
+    btn.frame = CGRectMake(50, 0, 200, 200);
+    btn.backgroundColor = [UIColor yellowColor];
+    [btn setTitle:@"HitTest" forState:UIControlStateNormal];
+    [btn addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
+    
+    [view addSubview:btn];
     self.emptyCustomView = view;
-     */
+ */
+}
+
+-(void)buttonTapped:(UIButton*)sender
+{
+    NSLog(@"HitTest successfull");
 }
 
 @end

--- a/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.h
+++ b/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.h
@@ -1,0 +1,13 @@
+//
+//  IBInspectableTableViewController.h
+//  BlazeExample
+//
+//  Created by Roy Derks on 15/11/2016.
+//  Copyright © 2016 GraafICT. All rights reserved.
+//
+
+#import "BaseTableViewController.h"
+
+@interface IBInspectableTableViewController : BaseTableViewController
+
+@end

--- a/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.m
@@ -63,10 +63,11 @@
     [section addRow:row];
     
     row = [BlazeRow rowWithXibName:kIBInspectableBlazeTextField];
-    row.placeholder = @"I want my to be baseline altered when active!";
+    row.placeholder = @"I want my baseline to be altered when active!";
     row.configureCell = ^(UITableViewCell *cell){
         BlazeTextFieldTableViewCell* aCell = (BlazeTextFieldTableViewCell*)cell;
-        aCell.textField.flKeepBaseline = FALSE;
+        aCell.textField.flAlterBaseline = TRUE;
+        aCell.textField.flAlwaysShow = FALSE;
         [aCell updateCell];
     };
     row.value = nil;

--- a/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.m
@@ -1,0 +1,79 @@
+//
+//  IBInspectableTableViewController.m
+//  BlazeExample
+//
+//  Created by Roy Derks on 15/11/2016.
+//  Copyright © 2016 GraafICT. All rights reserved.
+//
+
+#import "IBInspectableTableViewController.h"
+#import "BlazeTextFieldTableViewCell.h"
+
+@interface IBInspectableTableViewController () <UITextFieldDelegate>
+
+@end
+
+@implementation IBInspectableTableViewController
+
+-(void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.loadContentOnAppear = TRUE;
+}
+
+-(void)loadTableContent
+{
+    //Row & Section
+    BlazeRow *row;
+    BlazeSection *section;
+    
+    //BlazeTextField with IBInspectable's set in corresponding XIB file.
+    section = [[BlazeSection alloc] initWithHeaderXibName:kTableHeaderView headerTitle:@"Now an awesome float-label textfield with properties set through Interface Builder and code"];
+    [self addSection:section];
+    
+    row = [BlazeRow rowWithXibName:kIBInspectableBlazeTextField];
+    row.floatingTitle = @"I'm completely configured through IBInspectables!";
+    [section addRow:row];
+    
+    row = [BlazeRow rowWithXibName:kIBInspectableBlazeTextField];
+    row.floatingTitle = @"Now I'm orange whilst active!";
+    row.floatingTitleActiveColor = [UIColor orangeColor];
+    [section addRow:row];
+    
+    row = [BlazeRow rowWithXibName:kIBInspectableBlazeTextField];
+    row.floatingLabelEnabled = FloatingLabelStateDisabled;
+    row.placeholder = @"I don't use a floating label.";
+    row.value = nil;
+    [section addRow:row];
+    
+    row = [BlazeRow rowWithXibName:kIBInspectableBlazeTextField];
+    row.placeholderColor = [UIColor orangeColor];
+    row.floatingTitle = @"With a padded, blue Floating label!";
+    row.floatingTitleColor = [UIColor blueColor];
+    row.floatingTitleActiveColor = [UIColor blueColor];
+    row.placeholder = @"I am an orange placeholder!";
+    row.configureCell = ^(UITableViewCell *cell){
+        BlazeTextFieldTableViewCell* aCell = (BlazeTextFieldTableViewCell*)cell;
+        aCell.textField.flAlwaysShow = FALSE;
+        aCell.textField.clipsToBounds = FALSE;
+        aCell.textField.flYPadding = -20.f;
+        [aCell updateCell];
+    };
+    row.value = nil;
+    [section addRow:row];
+    
+    row = [BlazeRow rowWithXibName:kIBInspectableBlazeTextField];
+    row.placeholder = @"I want my to be baseline altered when float-label is shown!";
+    row.configureCell = ^(UITableViewCell *cell){
+        BlazeTextFieldTableViewCell* aCell = (BlazeTextFieldTableViewCell*)cell;
+        aCell.textField.flKeepBaseline = FALSE;
+        [aCell updateCell];
+    };
+    row.value = nil;
+    [section addRow:row];
+    
+    
+    [self reloadTable:true];
+}
+
+@end

--- a/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/IBInspectableTableViewController.m
@@ -63,7 +63,7 @@
     [section addRow:row];
     
     row = [BlazeRow rowWithXibName:kIBInspectableBlazeTextField];
-    row.placeholder = @"I want my to be baseline altered when float-label is shown!";
+    row.placeholder = @"I want my to be baseline altered when active!";
     row.configureCell = ^(UITableViewCell *cell){
         BlazeTextFieldTableViewCell* aCell = (BlazeTextFieldTableViewCell*)cell;
         aCell.textField.flKeepBaseline = FALSE;


### PR DESCRIPTION
Large refactor and bug fixes for BlazeTextField floating label, BlazeRow and BlazeTableViewCell.
- Added an interface to test the BlazeTextField inspectables;
- Added ENUM for the enabled state of Floating Label. Whilst using a BOOL you are not able to determine whether the IBInspectable is set and if its been overridden through code, as the code default will always be FALSE, or TRUE for that matter;
- Added more consistency to BlazeTextField (_ => self. and NO/YES => FALSE/TRUE);
- Renamed confusing properties on BlazeRow regarding the Floating Title and default Placeholder;
- Fixed many bugs regarding Placeholders and Floating titles;
- Fixed active state only being set when the text length was > 0;
- Made BlazeTableViewController compatible with CustomView property within DZNDataSource.

Tested on both the existing cells in Different Cell Types and IBInspectables view controllers.