### PR TITLE
Textfield Prefix and delegate completion blocks added.

### DIFF
--- a/Blaze/Objects/BlazeRow.h
+++ b/Blaze/Objects/BlazeRow.h
@@ -26,6 +26,8 @@ typedef NS_ENUM(NSInteger, ImageType) {
     ImageFromData,
 };
 
+@class BlazeTextField;
+
 @interface BlazeRow : NSObject
 {
     
@@ -77,6 +79,9 @@ typedef NS_ENUM(NSInteger, ImageType) {
 @property(nonatomic,copy) void (^doneChanging)(void);
 @property(nonatomic,copy) void (^configureCell)(UITableViewCell *cell);
 @property(nonatomic,copy) void (^multipleSelectionFinished)(NSMutableArray *selectedIndexPaths);
+@property(nonatomic,copy) void (^textFieldDidBeginEditing)(BlazeTextField* textField);
+@property(nonatomic,copy) void (^textFieldDidEndEditing)(BlazeTextField* textField);
+@property(nonatomic,copy) BOOL (^textFieldShouldChangeCharactersInRange)(BlazeTextField *textField, NSRange range, NSString *replacementString);
 
 //Row primitives
 @property(nonatomic) int ID;
@@ -213,6 +218,7 @@ typedef NS_ENUM(NSInteger, ImageType) {
 @property(nonatomic,strong) NSString *placeholder;
 @property(nonatomic,strong) NSFormatter *formatter;
 @property(nonatomic,strong) UIColor *placeholderColor;
+@property(nonatomic,strong) NSString *textFieldPrefix;
 @property(nonatomic,strong) NSString *textFieldSuffix;
 @property(nonatomic,strong) NSAttributedString *attributedPlaceholder;
 

--- a/Blaze/Objects/BlazeTextFieldProcessor.m
+++ b/Blaze/Objects/BlazeTextFieldProcessor.m
@@ -38,9 +38,14 @@
         self.textField.text = self.row.value;
     }
     
-    //Suffix
-    if(self.row.textFieldSuffix.length) {
+    if(self.row.textFieldPrefix.length && self.row.textFieldSuffix.length) {
+        self.textField.text = [NSString stringWithFormat:@"%@%@%@", self.row.textFieldPrefix, self.textField.text, self.row.textFieldSuffix];
+    }
+    else if(self.row.textFieldSuffix.length) {
         self.textField.text = [self.textField.text stringByAppendingString:self.row.textFieldSuffix];
+    }
+    else if(self.row.textFieldPrefix.length) {
+        self.textField.text = [self.row.textFieldPrefix stringByAppendingString:self.textField.text];
     }
     
     //Properties
@@ -67,17 +72,35 @@
     if(self.row.textFieldSuffix.length) {
         textField.text = [textField.text stringByReplacingOccurrencesOfString:self.row.textFieldSuffix withString:@""];
     }
+    if(self.row.textFieldPrefix.length) {
+        textField.text = [textField.text stringByReplacingCharactersInRange:NSMakeRange(0, self.row.textFieldPrefix.length) withString:@""];
+    }
+    if(self.row.textFieldDidBeginEditing) {
+        self.row.textFieldDidBeginEditing(self.textField);
+    }
 }
 
 -(void)textFieldDidEndEditing:(UITextField *)textField
 {
-    if(self.row.textFieldSuffix.length) {
+    if(self.row.textFieldPrefix.length && self.row.textFieldSuffix.length) {
+        textField.text = [NSString stringWithFormat:@"%@%@%@", self.row.textFieldPrefix, self.textField.text, self.row.textFieldSuffix];
+    }
+    else if(self.row.textFieldSuffix.length) {
         textField.text = [textField.text stringByAppendingString:self.row.textFieldSuffix];
+    }
+    else if(self.row.textFieldPrefix.length) {
+        textField.text = [self.row.textFieldPrefix stringByAppendingString:self.textField.text];
+    }
+    if(self.row.textFieldDidEndEditing) {
+        self.row.textFieldDidEndEditing(self.textField);
     }
 }
 
 -(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
+    if(self.row.textFieldShouldChangeCharactersInRange) {
+        return self.row.textFieldShouldChangeCharactersInRange(self.textField, range, string);
+    }
     self.row.value = [textField.text stringByReplacingCharactersInRange:range withString:string];
     if(self.row.formatter) {
         if([self.row.formatter isKindOfClass:[NSNumberFormatter class]]) {

--- a/Example/BlazeExample/ViewControllers/CellTypesTableViewController.m
+++ b/Example/BlazeExample/ViewControllers/CellTypesTableViewController.m
@@ -9,6 +9,7 @@
 #import "Constants.h"
 #import "BlazeInputTile.h"
 #import "CellTypesTableViewController.h"
+#import "BlazeTextField.h"
 
 @interface CellTypesTableViewController ()
 {
@@ -129,8 +130,27 @@
     row.formatter = nf;
     row.keyboardType = UIKeyboardTypeDecimalPad;
     row.textFieldSuffix = @" awesome suffix";
+    row.textFieldPrefix = @"cool prefix ";
     [row setValueChanged:^{
-        DLog(@"Suffix field changed: %@", self.textFieldNumberValue);
+        DLog(@"Suffix/prefix field changed: %@", self.textFieldNumberValue);
+    }];
+    [section addRow:row];
+    
+    //Textfield completion blocks
+    row = [[BlazeRow alloc] initWithXibName:kFloatTextFieldTableViewCell];
+    row.floatingLabelEnabled = FALSE;
+    row.placeholder = @"Textfield with numerous completion blocks";
+    row.textFieldDidBeginEditing = ^(BlazeTextField* textField) {
+        textField.placeholder = @"I have started editing!";
+    };
+    row.textFieldDidEndEditing = ^(BlazeTextField* textField) {
+        SuppressDeprecatedWarning(showM1(@"I have ended editing now!"));
+        textField.text = nil;
+        textField.placeholder = @"Textfield with numerous completion blocks";
+    };
+    [row setTextFieldShouldChangeCharactersInRange:^BOOL(BlazeTextField *textField, NSRange range, NSString *replacementString) {
+        textField.text = @"Am I interfering?";
+        return true;
     }];
     [section addRow:row];
     


### PR DESCRIPTION
Hi Bob,

In this PR i have added the following:

Added textField prefix and completion blocks to row and processor.
These blocks correspond to begin- and end editing. Block for textFieldShouldChangeCharactersInRange overwrites base functionality.
Updated example project accordingly.